### PR TITLE
Added Hashrate Reporting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	GasMultiplier                float32       `json:"gasMultiplier"`
 	GasMax                       uint          `json:"gasMax"`
 	NumProcessors                int           `json:"numProcessors"`
+	Heartbeat                    int           `json:"heartbeat"`
 	ServerWhitelist              []string      `json:"serverWhitelist"`
 	logger                       *util.Logger
 	mux                          sync.Mutex
@@ -43,6 +44,8 @@ const defaultTimeout = 30 //30 second fetch timeout
 const defaultRequestInterval = 30 //30 seconds between data requests (0-value tipping)
 const defaultMiningInterrupt = 15 //every 15 seconds, check for new challenges that could interrupt current mining
 const defaultCores = 2
+
+const defaultHeartbeat = 10000000 //check miner speed every 10 ^ 7 cycles
 
 var (
 	config *Config
@@ -84,6 +87,10 @@ func ParseConfig(path string) (*Config, error) {
 	}
 	if config.NumProcessors == 0 {
 		config.NumProcessors = defaultCores
+	}
+
+	if config.Heartbeat == 0 {
+		config.Heartbeat = defaultHeartbeat
 	}
 
 	if len(config.ServerWhitelist) == 0{

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ const defaultRequestInterval = 30 //30 seconds between data requests (0-value ti
 const defaultMiningInterrupt = 15 //every 15 seconds, check for new challenges that could interrupt current mining
 const defaultCores = 2
 
-const defaultHeartbeat = 10000000 //check miner speed every 10 ^ 7 cycles
+const defaultHeartbeat = 100000000 //check miner speed every 10 ^ 8 cycles
 
 var (
 	config *Config

--- a/pow/miningLoop.go
+++ b/pow/miningLoop.go
@@ -170,11 +170,20 @@ func (ml *miningLoop) solveChallenge() {
 	x := new(big.Int)
 	compareZero := big.NewInt(0)
 
+        // Variables for measuring hashrate
+	j := i
+	sampleTime := startTime
+	heartbeat:= cfg.Heartbeat
 	for {
 
 		i++
-		if i%100000000 == 0 {
+		if i % heartbeat == 0 {
 			ml.log.Info("Still Mining")
+			timeDelta := time.Now().Sub(sampleTime)
+			sampleTime = time.Now()
+			iDelta := i - j
+			j = i
+			ml.log.Info("Hashrate: %v ", float64(iDelta) / timeDelta.Seconds())
 		}
 		if !ml.canMine {
 			ml.log.Info("Stopping computation loop since asked to stop mining")

--- a/pow/miningLoop.go
+++ b/pow/miningLoop.go
@@ -170,7 +170,7 @@ func (ml *miningLoop) solveChallenge() {
 	x := new(big.Int)
 	compareZero := big.NewInt(0)
 
-        // Variables for measuring hashrate
+	// Variables for measuring hashrate
 	j := i
 	sampleTime := startTime
 	heartbeat:= cfg.Heartbeat


### PR DESCRIPTION
This is a simple implementation of hashrate reporting. A configuration parameter `heartbeat` controls the frequency that hashrate is measured, this works as a "heartbeat" for making sure the miner is still mining. Setting the heartbeat to 500,000 seemed to yield a good result for me on my Xeon.