### PR TITLE
Added working tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,8 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
+	"io/ioutil"
 	"strings"
 	"time"
 )
@@ -103,22 +102,15 @@ const DefaultDisputeThreshold = 0.01
 
 //ParseConfig and set a shared config entry
 func ParseConfig(path string) error {
-	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return fmt.Errorf("Invalid ConfigPath setting: %s", path)
-	}
-	if info.IsDir() {
-		return fmt.Errorf("ConfigPath is a directory: %s", path)
-	}
-
-	configFile, err := os.Open(path)
+	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to open config file %s: %v", path, err)
 	}
-	defer configFile.Close()
+	return ParseConfigBytes(data)
+}
 
-	dec := json.NewDecoder(configFile)
-	err = dec.Decode(&config)
+func ParseConfigBytes(data []byte) error {
+	err := json.Unmarshal(data, &config)
 	if err != nil {
 		return fmt.Errorf("failed to parse json: %s", err.Error())
 	}
@@ -150,10 +142,6 @@ func ParseConfig(path string) error {
 		}
 	}
 
-	if config.PSRFolder == "" {
-		config.PSRFolder = filepath.Dir(path)
-	}
-
 	config.PrivateKey = strings.ToLower(strings.ReplaceAll(config.PrivateKey, "0x", ""))
 	config.PublicAddress = strings.ToLower(strings.ReplaceAll(config.PublicAddress, "0x", ""))
 
@@ -176,15 +164,18 @@ func ParseConfig(path string) error {
 func validateConfig(cfg *Config) error {
 	b, err := hex.DecodeString(cfg.PublicAddress)
 	if err != nil || len(b) != 20 {
-		return fmt.Errorf("expecting 40 hex character public address, got %s", cfg.PublicAddress)
+		return fmt.Errorf("expecting 40 hex character public address, got \"%s\"", cfg.PublicAddress)
 	}
 	b, err = hex.DecodeString(cfg.PrivateKey)
 	if err != nil || len(b) != 32 {
-		return fmt.Errorf("expecting 64 hex character private key, got %s", cfg.PublicAddress)
+		return fmt.Errorf("expecting 64 hex character private key, got \"%s\"", cfg.PrivateKey)
+	}
+	if len(cfg.ContractAddress) != 42 {
+		return fmt.Errorf("expecting 40 hex character contract address, got \"%s\"", cfg.ContractAddress)
 	}
 	b, err = hex.DecodeString(cfg.ContractAddress[2:])
 	if err != nil || len(b) != 20 {
-		return fmt.Errorf("expecting 40 hex character contract address, got %s", cfg.ContractAddress)
+		return fmt.Errorf("expecting 40 hex character contract address, got \"%s\"", cfg.ContractAddress)
 	}
 
 	if cfg.GasMultiplier < 0 || cfg.GasMultiplier > 20 {
@@ -196,13 +187,13 @@ func validateConfig(cfg *Config) error {
 			continue
 		}
 		if gpuConfig.Count == 0 {
-			return fmt.Errorf("gpu %s requires 'count' > 0", name)
+			return fmt.Errorf("gpu '%s' requires 'count' > 0", name)
 		}
 		if gpuConfig.GroupSize == 0 {
-			return fmt.Errorf("gpu %s requires 'groupSize' > 0", name)
+			return fmt.Errorf("gpu '%s' requires 'groupSize' > 0", name)
 		}
 		if gpuConfig.Groups == 0 {
-			return fmt.Errorf("gpu %s requires 'groups' > 0", name)
+			return fmt.Errorf("gpu '%s' requires 'groups' > 0", name)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,8 @@ var (
 	config *Config
 )
 
+const defaultTrackerInterval = 30 * time.Second
+
 const DefaultMaxCheckTimeDelta = 5 * time.Minute
 
 //threshold, a percentage of the expected value
@@ -125,6 +127,9 @@ func ParseConfigBytes(data []byte) error {
 	}
 	if config.NumProcessors == 0 {
 		config.NumProcessors = defaultCores
+	}
+	if config.TrackerSleepCycle.Duration == 0 {
+		config.TrackerSleepCycle.Duration = defaultTrackerInterval
 	}
 
 	if config.Heartbeat.Seconds() == 0 {

--- a/ops/disputeOps.go
+++ b/ops/disputeOps.go
@@ -277,7 +277,7 @@ func List(ctx context.Context) error {
 		fmt.Printf("    Currently %.0f%% of %s TRB support this dispute (%s votes)\n", currTallyRatio*100, util.FormatERC20Balance(uintVars[7]), uintVars[4])
 
 		result := tracker.CheckValueAtTime(dispute.RequestId.Uint64(), uintVars[2], disputedValTime)
-		if len(result.Datapoints) < 0 {
+		if result == nil || len(result.Datapoints) < 0 {
 			fmt.Printf("      No data available for recommendation\n")
 			continue
 		}

--- a/pow/miningGroup_test.go
+++ b/pow/miningGroup_test.go
@@ -26,7 +26,7 @@ func createChallenge(id int, difficulty int64) *MiningChallenge {
 }
 
 func CheckSolution(t *testing.T, challenge *MiningChallenge, nonce string) {
-	cfg := config.GetMockConfig()
+	cfg := config.GetConfig()
 	_string := fmt.Sprintf("%x", challenge.Challenge) + cfg.PublicAddress
 	hashIn := decodeHex(_string)
 	hashIn = append(hashIn, []byte(nonce)...)
@@ -40,7 +40,7 @@ func CheckSolution(t *testing.T, challenge *MiningChallenge, nonce string) {
 }
 
 func DoCompleteMiningLoop(t *testing.T, impl Hasher, diff int64) {
-	cfg := config.GetMockConfig()
+	cfg := config.GetConfig()
 
 	group := NewMiningGroup([]Hasher{impl})
 
@@ -92,7 +92,7 @@ func TestGpuMiner(t *testing.T) {
 		fmt.Println(gpus)
 		t.Fatal(err)
 	}
-	cfg := config.GetMockConfig()
+	cfg := config.GetConfig()
 
 	impl, err := NewGpuMiner(gpus[0], cfg.GPUConfig[gpus[0].Name()])
 	if err != nil {
@@ -105,7 +105,7 @@ func TestMulti(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	cfg := config.GetMockConfig()
+	cfg := config.GetConfig()
 
 	var hashers []Hasher
 	for i := 0; i < 4; i++ {

--- a/runTest.sh
+++ b/runTest.sh
@@ -2,9 +2,6 @@
 
 NAME="$1"
 PKG="$2"
-PSR=`pwd`/psr.json
-CFG=`pwd`/myconfig.json
-LOG=`pwd`/loggingConfig.json
 
 if [ -z "${NAME}" ]; then
   echo "Missing test name";
@@ -17,4 +14,4 @@ if [ -z "${PKG}" ]; then
 fi
 
 echo "Running test ${NAME} from package  ${PKG}..."
-go test -v -run "${NAME}" "./${PKG}" -psrPath="${PSR}" -config="${CFG}" -logConfig="${LOG}"
+go test -v -run "${NAME}" "./${PKG}" 

--- a/tracker/dataWindow.go
+++ b/tracker/dataWindow.go
@@ -74,7 +74,6 @@ func (w *Window)WithinRange(at time.Time, delta time.Duration) []*TimedInt {
 		i++
 	}
 	return items
-
 }
 
 func (w *Window)Insert(x *TimedInt) {

--- a/tracker/disputeChecker.go
+++ b/tracker/disputeChecker.go
@@ -44,7 +44,6 @@ func CheckValueAtTime(reqId uint64, val *big.Int, at time.Time) *ValueCheckResul
 
 	if len(datapoints) == 0 {
 		//no data for requestID
-		disputeLogger.Warn("no value data for reqID %d at %s", reqId, at)
 		return nil
 	}
 
@@ -138,6 +137,10 @@ func (c *disputeChecker) Exec(ctx context.Context) error {
 		}
 		reqID := nonceSubmit.RequestId.Uint64()
 		result := CheckValueAtTime(reqID, nonceSubmit.Value, blockTime)
+		if result == nil {
+			disputeLogger.Warn("no value data for reqID %d at %s", reqID, blockTime)
+			continue
+		}
 		if !result.WithinRange {
 			s := fmt.Sprintf("suspected incorrect value for requestID %d at %s:\n", reqID, blockTime)
 			s += fmt.Sprintf("nearest values:\n")

--- a/tracker/main_test.go
+++ b/tracker/main_test.go
@@ -1,0 +1,29 @@
+package tracker
+
+import (
+	"fmt"
+	"github.com/tellor-io/TellorMiner/config"
+	"github.com/tellor-io/TellorMiner/util"
+	"os"
+	"testing"
+)
+
+var configJSON = `{
+	"publicAddress":"0000000000000000000000000000000000000000",
+	"privateKey":"1111111111111111111111111111111111111111111111111111111111111111",
+	"contractAddress":"0x724D1B69a7Ba352F11D73fDBdEB7fF869cB22E19",
+	"psrFolder": ".."
+}
+`
+
+func TestMain(m *testing.M) {
+	err := config.ParseConfigBytes([]byte(configJSON))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse mock config: %v\n", err)
+		os.Exit(-1)
+	}
+	util.ParseLoggingConfig("")
+	EnsureValueOracle()
+	os.Exit(m.Run())
+}
+

--- a/tracker/psr_test.go
+++ b/tracker/psr_test.go
@@ -28,7 +28,10 @@ func TestPSR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	psr.Exec(ctx)
+	err = psr.Exec(ctx)
+	if err != nil {
+		t.Fatalf("failed to execute psr: %v", err)
+	}
 	val, err := db.Get(fmt.Sprintf("qv_%d", 1))
 	if err != nil {
 		t.Fatal(err)

--- a/util/logConfig.go
+++ b/util/logConfig.go
@@ -2,7 +2,7 @@ package util
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"os"
 )
 
@@ -24,15 +24,15 @@ var (
 //ParseLoggingConfig parses the given JSON log level config file for use in log configuration
 func ParseLoggingConfig(file string) error {
 
-	info, err := os.Stat(file)
-	if os.IsNotExist(err) {
-		log.Fatalf("LoggingConfigPath references an invalid file at: %s", file)
-	}
-	if info.IsDir() {
-		log.Fatalf("Logging config file %s is a directory", file)
-	}
-
 	if len(file) > 0 {
+		info, err := os.Stat(file)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("loggingConfigPath references an invalid file at: %s", file)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("logging config file %s is a directory", file)
+		}
+
 		configFile, err := os.Open(file)
 		defer configFile.Close()
 		if err != nil {


### PR DESCRIPTION
This should allow `go test` to be run in both pow and tracker. No arguments are needed. Other packages already had failing tests, if needed they can be brought back to working using the example code in the `TestMain` functions in both `pow` and `tracker`. 

