### PR TITLE
Fixed submit job failure stalls miner

### DIFF
--- a/pow/pool.go
+++ b/pow/pool.go
@@ -114,8 +114,7 @@ func (p *Pool) Submit(ctx context.Context, result *Result) {
 	resp, err := cli.Do(req)
 	if err != nil {
 		p.log.Error("Error posting nonce:", err.Error())
-	} else {
-		resp.Body.Close()
-		p.currJobID = 0
 	}
+	resp.Body.Close()
+	p.currJobID = 0
 }

--- a/pow/pool.go
+++ b/pow/pool.go
@@ -113,9 +113,7 @@ func (p *Pool) Submit(ctx context.Context, result *Result) {
 	cli := &http.Client{}
 	resp, err := cli.Do(req)
 	if err != nil {
-		p.log.Error("Problem submitting txn", err)
 		p.log.Error("Error posting nonce:", err.Error())
-		return
 	} else {
 		resp.Body.Close()
 		p.currJobID = 0


### PR DESCRIPTION
When the POST request fails, the miner stalls out. This PR will stop the miner from stalling but doesn't add any type of retry. 