### PR TITLE
fixed pool crash, true hash rate printout, added delay to dispute checker

### DIFF
--- a/pow/pool.go
+++ b/pow/pool.go
@@ -114,7 +114,8 @@ func (p *Pool) Submit(ctx context.Context, result *Result) {
 	resp, err := cli.Do(req)
 	if err != nil {
 		p.log.Error("Error posting nonce:", err.Error())
+	} else {
+		resp.Body.Close()
 	}
-	resp.Body.Close()
 	p.currJobID = 0
 }


### PR DESCRIPTION
Few miscellaneous improvements.

* Fixed a bug in the pool logic that crashed when submitting failed
* Hash rates printed are now true measurements
* Dispute checker now only looks at values at least 75 blocks old (~16 minutes)