### PR TITLE
changed big.Int to floats internally

### DIFF
--- a/ops/disputeOps.go
+++ b/ops/disputeOps.go
@@ -92,7 +92,7 @@ func Vote(_disputeId *big.Int, _supportsDispute bool, ctx context.Context) error
 	return nil
 }
 
-func getNonceSubmissions(ctx context.Context, valueBlock *big.Int, dispute *tellor1.TellorDisputeNewDispute) ([]*tracker.TimedInt, error) {
+func getNonceSubmissions(ctx context.Context, valueBlock *big.Int, dispute *tellor1.TellorDisputeNewDispute) ([]*tracker.TimedFloat, error) {
 	instance := ctx.Value(tellorCommon.MasterContractContextKey).(*tellor.TellorMaster)
 	tokenAbi, err := abi.JSON(strings.NewReader(tellor1.TellorLibraryABI))
 	if err != nil {
@@ -119,7 +119,7 @@ func getNonceSubmissions(ctx context.Context, valueBlock *big.Int, dispute *tell
 	high := int64(valueBlock.Uint64())
 	low := high - blockStep
 	nonceSubmitID := tokenAbi.Events["NonceSubmitted"].ID()
-	timedValues := make([]*tracker.TimedInt, 5)
+	timedValues := make([]*tracker.TimedFloat, 5)
 	found := 0
 	for found < 5 {
 		query := ethereum.FilterQuery{
@@ -148,15 +148,18 @@ func getNonceSubmissions(ctx context.Context, valueBlock *big.Int, dispute *tell
 				if nonceSubmit.Miner == allAddrs[i] {
 					valTime := time.Unix(int64(header.Time), 0)
 
-					timedValues[i] = &tracker.TimedInt{
+					bigF := new(big.Float)
+					bigF.SetInt(allVals[i])
+					f, _ := bigF.Float64()
+
+					timedValues[i] = &tracker.TimedFloat{
 						Created: valTime,
-						Val: allVals[i].Uint64(),
+						Val: f,
 					}
 					found++
 					break
 				}
 			}
-
 		}
 		high -= blockStep
 		low = high - blockStep

--- a/release_build.sh
+++ b/release_build.sh
@@ -1,1 +1,13 @@
-go build -ldflags "-X main.GitTag=$(git describe --tags) -X main.GitHash=$(git rev-parse --short HEAD) -s -w"
+#!/bin/bash
+LDFLAGS="-X main.GitTag=$(git describe --tags) -X main.GitHash=$(git rev-parse --short HEAD) -s -w"
+
+
+#linux
+go build -ldflags "$LDFLAGS"
+
+#windows
+CC="x86_64-w64-mingw32-gcc-win32" GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build -ldflags "$LDFLAGS"
+
+
+
+

--- a/tracker/dataWindow.go
+++ b/tracker/dataWindow.go
@@ -5,13 +5,13 @@ import (
 	"time"
 )
 
-type TimedInt struct {
+type TimedFloat struct {
 	Created time.Time
-	Val     uint64
+	Val     float64
 }
 
 type Window struct {
-	buffer []*TimedInt
+	buffer []*TimedFloat
 	start int
 	num int
 	keep time.Duration
@@ -40,7 +40,7 @@ func (w *Window)Trim() {
 	}
 }
 
-func (w *Window)ClosestTwo(at time.Time) (before, after *TimedInt) {
+func (w *Window)ClosestTwo(at time.Time) (before, after *TimedFloat) {
 	if w.num == 0 {
 		return
 	}
@@ -58,8 +58,8 @@ func (w *Window)ClosestTwo(at time.Time) (before, after *TimedInt) {
 	return
 }
 
-func (w *Window)WithinRange(at time.Time, delta time.Duration) []*TimedInt {
-	var items []*TimedInt
+func (w *Window)WithinRange(at time.Time, delta time.Duration) []*TimedFloat {
+	var items []*TimedFloat
 	i := 0
 	n := len(w.buffer)
 	for i < w.num {
@@ -76,7 +76,7 @@ func (w *Window)WithinRange(at time.Time, delta time.Duration) []*TimedInt {
 	return items
 }
 
-func (w *Window)Insert(x *TimedInt) {
+func (w *Window)Insert(x *TimedFloat) {
 	now := time.Now()
 	t := x.Created
 	latest := w.Latest()
@@ -89,7 +89,7 @@ func (w *Window)Insert(x *TimedInt) {
 	if w.num == n {
 		newLen := 2*n
 		if newLen == 0 { newLen = 1 }
-		bigger := make([]*TimedInt, newLen)
+		bigger := make([]*TimedFloat, newLen)
 		for i := 0; i < w.num; i++ {
 			bigger[i] = w.buffer[(w.start + i) % n]
 		}
@@ -106,7 +106,7 @@ func (w *Window)Len() int {
 	return w.num
 }
 
-func (w *Window)Latest() *TimedInt {
+func (w *Window)Latest() *TimedFloat {
 	w.Trim()
 	if w.num == 0 {
 		return nil
@@ -117,7 +117,7 @@ func (w *Window)Latest() *TimedInt {
 
 
 func (w *Window) UnmarshalJSON(b []byte) error {
-	var v []*TimedInt
+	var v []*TimedFloat
 	err := json.Unmarshal(b, &v)
 	if err != nil {
 		return err
@@ -134,7 +134,7 @@ func (w *Window) UnmarshalJSON(b []byte) error {
 
 func (w *Window) MarshalJSON() ([]byte, error) {
 	w.Trim()
-	a := make([]*TimedInt, w.num)
+	a := make([]*TimedFloat, w.num)
 	n := len(w.buffer)
 	for i := 0; i < w.num; i++ {
 		a[i] = w.buffer[(w.start + i) % n]

--- a/tracker/disputeChecker.go
+++ b/tracker/disputeChecker.go
@@ -34,7 +34,7 @@ func (c *disputeChecker) String() string {
 type ValueCheckResult struct {
 	High, Low float64
 	WithinRange bool
-	Datapoints []*TimedInt
+	Datapoints []*TimedFloat
 }
 
 func CheckValueAtTime(reqId uint64, val *big.Int, at time.Time) *ValueCheckResult {

--- a/tracker/fetchData.go
+++ b/tracker/fetchData.go
@@ -68,7 +68,10 @@ func (b *RequestDataTracker) Exec(ctx context.Context) error {
 				return
 			}
 			fetchLog.Debug("Storing fetch result: %v for id: %d", res.value, res.reqID)
-			setRequestValue(uint64(res.reqID), time.Now(), res.value)
+			bigF := new(big.Float)
+			bigF.SetInt(res.value)
+			f, _ := bigF.Float64()
+			setRequestValue(uint64(res.reqID), time.Now(), f)
 			//always write out non-psr data to the DB immediately
 			enc := hexutil.EncodeBig(res.value)
 			DB.Put(fmt.Sprintf("%s%d", db.QueriedValuePrefix, res.reqID), []byte(enc))

--- a/tracker/psr.go
+++ b/tracker/psr.go
@@ -117,19 +117,21 @@ func (r PrespecifiedRequest) Exec(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	bigVal := new(big.Int)
-	bigVal.SetUint64(val)
 
 	//save the value into our local data window no matter what
-	setRequestValue(r.RequestID, time.Now(), bigVal)
+	setRequestValue(r.RequestID, time.Now(), val)
 
 	//if we have enough data saved in the window to make an accurate reading,
 	//place the value into the DB so it can be submitted during mining
 	//if value returns nil, we don't have enough saved yet
-	value := r.Transformation.Value(&r)
-	if value != nil {
+	value,ok := r.Transformation.Value(&r)
+	if ok {
+		bigVal := new(big.Float)
+		bigVal.SetFloat64(value)
+		bigInt := new(big.Int)
+		bigVal.Int(bigInt)
 		DB := ctx.Value(tellorCommon.DBContextKey).(db.DB)
-		enc := hexutil.EncodeBig(bigVal)
+		enc := hexutil.EncodeBig(bigInt)
 		err := DB.Put(fmt.Sprintf("%s%d", db.QueriedValuePrefix, r.RequestID), []byte(enc))
 		if err != nil {
 			return err

--- a/tracker/valueOracle.go
+++ b/tracker/valueOracle.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/tellor-io/TellorMiner/config"
 	"io/ioutil"
-	"math/big"
 	"os"
 	"path/filepath"
 	"sync"
@@ -19,7 +18,7 @@ var valueHistoryMutex sync.RWMutex
 //last time PSR windows written to disk
 var lastHistoryWriteAttempt time.Time
 
-func GetLatestRequestValue(id uint64) *TimedInt {
+func GetLatestRequestValue(id uint64) *TimedFloat {
 	valueHistoryMutex.RLock()
 	defer valueHistoryMutex.RUnlock()
 	w, ok := valueHistory[id]
@@ -29,7 +28,7 @@ func GetLatestRequestValue(id uint64) *TimedInt {
 	return w.Latest()
 }
 
-func GetRequestValuesForTime(id uint64, at time.Time, delta time.Duration) []*TimedInt {
+func GetRequestValuesForTime(id uint64, at time.Time, delta time.Duration) []*TimedFloat {
 	valueHistoryMutex.RLock()
 	defer valueHistoryMutex.RUnlock()
 	w, ok := valueHistory[id]
@@ -39,16 +38,16 @@ func GetRequestValuesForTime(id uint64, at time.Time, delta time.Duration) []*Ti
 	return w.WithinRange(at, delta)
 }
 
-func setRequestValue(id uint64, at time.Time, val *big.Int) {
+func setRequestValue(id uint64, at time.Time, val float64) {
 
 	valueHistoryMutex.Lock()
 	_, ok := valueHistory[id]
 	if !ok {
 		valueHistory[id] = NewWindow(7 * 24 * time.Hour)
 	}
-	valueHistory[id].Insert(&TimedInt{
+	valueHistory[id].Insert(&TimedFloat{
 		Created: at,
-		Val:val.Uint64(),
+		Val:val,
 	})
 	valueHistoryMutex.Unlock()
 }

--- a/tracker/valueProcessor.go
+++ b/tracker/valueProcessor.go
@@ -117,6 +117,10 @@ func parsePayloads(r *PrespecifiedRequest, payloads [][]byte) []float64 {
 // 6 hours old    0.50
 // 24 hours old   0.05
 func expTimeWeightedMean(vals []*TimedFloat) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+
 	now := time.Now()
 	sum := 0.0
 	for _,v := range vals {
@@ -127,6 +131,9 @@ func expTimeWeightedMean(vals []*TimedFloat) float64 {
 }
 
 func mean(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
 	//compute the mean
 	sum := 0.0
 	for _,v := range vals {
@@ -137,6 +144,10 @@ func mean(vals []float64) float64 {
 }
 
 func median(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+
 	sort.Slice(vals, func (i, j int) bool {
 		return vals[i] < vals[j]
 	})

--- a/tracker/valueProcessor.go
+++ b/tracker/valueProcessor.go
@@ -77,7 +77,8 @@ func (t TimeAverage)Value(r *PrespecifiedRequest) (float64, bool) {
 	//require at least 60% of the values from the past day
 	ratio := float64(len(vals))/float64(max)
 	if ratio < 0.6 {
-		estimate := time.Duration(0.6 * float64(timeInterval))
+		//this isn't perfectly accurate, but it's a good cheap estimate. And is this REALLY worth the time to do right?
+		estimate := time.Duration((0.6-ratio) * float64(timeInterval))
 		psrLog.Info("Insufficient data for request ID %d, expected in %s", r.RequestID, estimate.String())
 		return 0, false
 	}

--- a/util/jsonParser.go
+++ b/util/jsonParser.go
@@ -31,7 +31,7 @@ func ParseQueryString(_query string) (url string, args []string) {
 }
 
 //ParsePayload will extract the value from a query payload
-func ParsePayload(payload []byte, _granularity uint, args []string) (int, error) {
+func ParsePayload(payload []byte, _granularity uint, args []string) (float64, error) {
 	var f interface{}
 	if err := json.Unmarshal(payload, &f); err != nil {
 		fmt.Println(err)
@@ -43,7 +43,7 @@ func ParsePayload(payload []byte, _granularity uint, args []string) (int, error)
 		return 0,errors.New("JSON Parsing error")
 	}
 	s, _ := strconv.ParseFloat(fmt.Sprintf("%v", result), 64)
-	return int(s * float64(_granularity)), nil
+	return s * float64(_granularity), nil
 }
 
 var Bi = 0

--- a/windowsBuild.sh
+++ b/windowsBuild.sh
@@ -1,5 +1,0 @@
-
-#simple for now!
-CC="x86_64-w64-mingw32-gcc-win32" GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build
-
-


### PR DESCRIPTION
Improved the build script, now there is a single script that builds both the linux and windows miners. Adds the git-tag for the version as well as the sha into the build. Also strips symbols to reduce executable size (`-s -w`)

Logic as to why floats:

> ok im changing all the handling code for values to be floats
> because its way easier to write code that way
> and they have much more accuracy then we're ever going to get in the system anyways
> i was careful however, to make sure that we never store the result in a regular integer anymore
> so if we need a value that has more than ~19 digits provided by a 64 bit integer, it will still work
> a float has 16 digits of percision
> so now we can store a value with 20 digits, and the last 4 will be meaningless due to using floats
> but really everything past the 5-6 most significant digits is already garbage just because of how we're acquiring the data
> (which isn't a problem)
> 
