### PR TITLE
testing initial AMPL support

### DIFF
--- a/apiOracle/dataWindow.go
+++ b/apiOracle/dataWindow.go
@@ -5,10 +5,14 @@ import (
 	"time"
 )
 
+
+type PriceInfo struct {
+	Price, Volume float64
+}
+
 type PriceStamp struct {
 	Created time.Time
-	Price     float64
-	Volume 	  float64
+	PriceInfo
 }
 
 type Window struct {

--- a/apiOracle/valueOracle.go
+++ b/apiOracle/valueOracle.go
@@ -41,7 +41,7 @@ func GetRequestValuesForTime(id string, at time.Time, delta time.Duration) []*Pr
 	return w.WithinRange(at, delta)
 }
 
-func SetRequestValue(id string, at time.Time, price float64, volume float64) {
+func SetRequestValue(id string, at time.Time, info PriceInfo) {
 
 	valueHistoryMutex.Lock()
 	_, ok := valueHistory[id]
@@ -50,8 +50,7 @@ func SetRequestValue(id string, at time.Time, price float64, volume float64) {
 	}
 	valueHistory[id].Insert(&PriceStamp{
 		Created: at,
-		Price:price,
-		Volume:volume,
+		PriceInfo:info,
 	})
 	valueHistoryMutex.Unlock()
 }

--- a/indexes.json
+++ b/indexes.json
@@ -4,7 +4,7 @@
 	],
 	"AMPL/USD":[
 		"json(https://api.coingecko.com/api/v3/simple/price?ids=ampleforth&vs_currencies=usd).ampleforth.usd",
-		"json(https://api.kucoin.com/api/v1/market/stats?symbol=AMPL-USDT).data.last,.data.last",
+		"json(https://api.kucoin.com/api/v1/market/stats?symbol=AMPL-USDT).data.last,.data.vol",
 		"json(https://api-pub.bitfinex.com/v2/tickers?symbols=tAMPUST).0.7,.0.8",
 		"json(https://api-pub.bitfinex.com/v2/tickers?symbols=tAMPUSD).0.7,.0.8",
 		"json(https://min-api.cryptocompare.com/data/price?fsym=AMPL&tsyms=USD).USD"

--- a/ops/disputeOps.go
+++ b/ops/disputeOps.go
@@ -155,7 +155,7 @@ func getNonceSubmissions(ctx context.Context, valueBlock *big.Int, dispute *tell
 
 					timedValues[i] = &apiOracle.PriceStamp{
 						Created: valTime,
-						Price: f,
+						PriceInfo: apiOracle.PriceInfo{Price:f},
 					}
 					found++
 					break

--- a/tracker/ampl.go
+++ b/tracker/ampl.go
@@ -1,0 +1,83 @@
+package tracker
+
+import (
+	"fmt"
+	"github.com/tellor-io/TellorMiner/apiOracle"
+	"time"
+)
+
+type Ampl struct {
+	granularity float64
+}
+
+func (a Ampl)Require(at time.Time) map[string]IndexProcessor {
+	return map[string]IndexProcessor{
+		//make sure these are all returning the volume in AMPL
+		"AMPL/USD": VolumeWeightedAPIs(TimeWeightedAvg(24*time.Hour, NoDecay)),
+		"AMPL/BTC": AmpleChained("BTC/USD"),
+		//"AMPL/ETH": AmpleChained("ETH/USD"),
+	}
+}
+
+func (a Ampl) ValueAt(vals map[string]apiOracle.PriceInfo, at time.Time) float64 {
+	valSlice := make([]apiOracle.PriceInfo, 0, len(vals))
+	for _,v := range vals {
+		valSlice = append(valSlice, v)
+	}
+	return VolumeWeightedAvg(valSlice).Price * a.granularity
+}
+
+//compute the average ampl price over a 24 hour period using a chained price feed
+func AmpleChained(chainedPair string) IndexProcessor {
+	return func(apis []*IndexTracker, at time.Time) (apiOracle.PriceInfo, float64) {
+
+		//make sure the chained prices is working (everything in USD, not BTC)
+		eod := time.Now().UTC()
+		d := 24 * time.Hour
+		eod = eod.Truncate(d)
+		eod = eod.Add(17 * time.Hour)
+		eod = eod.Add(28 * time.Minute) //make this 2 am for live version
+		//Get the value always at 2am UTC
+		//time weight individual 10 minute buckets
+		//VWAP based on time at 2am
+		numVals := 0
+		//volumes := make(map[string]float64)
+		sum := 0.0
+		maxVolume := 0.0
+
+		interval := 10 * time.Minute
+
+		//function to collect API values over an interval
+		apiFn := VolumeWeightedAPIs(TimeWeightedAvg(interval, NoDecay))
+
+		for i:= 0; i < 10; i++ {
+			thisTime := eod.Add(time.Duration(-i) * interval)
+			chainedPrice, confidence := MedianAt(indexes[chainedPair], thisTime)
+			if confidence < 0.3 {
+				//we don't have an accurate estimate of the intermediary price, so we can't convert the AMPL price to USD
+				continue
+			}
+			avg, confidence := apiFn(apis, thisTime)
+			if confidence < 0.3 {
+				//our estimate of AMPL/intermediary is not good enough right now
+				continue
+			}
+			sum += avg.Price * chainedPrice.Price
+			if avg.Volume > maxVolume {
+				maxVolume = avg.Volume
+			}
+			numVals++
+		}
+		fmt.Println(numVals, "taken as part of the AMPL piece")
+		//fmt.Println("uniqueAPIs : ", uniqueApis)
+		var result apiOracle.PriceInfo
+		result.Price = sum / float64(numVals)
+		result.Volume = maxVolume
+		fmt.Println("Ample Price", result.Price, "   : Ample Confidence:  ", numVals/144.0)
+		if sum > 0 {
+			return result, float64(numVals) / 144.0
+		} else {
+			return result, 0
+		}
+	}
+}

--- a/tracker/index.go
+++ b/tracker/index.go
@@ -154,7 +154,7 @@ func (i *IndexTracker) Exec(ctx context.Context) error {
 	}
 
 	//save the value into our local data window (set 0 volume for now)
-	apiOracle.SetRequestValue(i.Identifier, time.Now(), vals[0], volume)
+	apiOracle.SetRequestValue(i.Identifier, time.Now(), apiOracle.PriceInfo{Price:vals[0], Volume:volume})
 
 	//update all the values that depend on these symbols
 	return UpdatePSRs(ctx, i.Symbols)

--- a/tracker/psrs.go
+++ b/tracker/psrs.go
@@ -14,116 +14,116 @@ var switchTime, _ = time.Parse(time.RFC3339, "2010-06-01T00:00:00+00:00")
 
 var PSRs = map[int]ValueGenerator{
 	// 1: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "ETH/USD~api.pro.coinbase.com", granularity: 1000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "ETH/USD", granularity: 1000000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "ETH/USD~api.pro.coinbase.com", granularity: 1000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "ETH/USD", granularity: 1000000, transform: MedianAt},
 	// 	at:     switchTime,
 	// },
-	2: &TimedSwitch{
-		before: &SingleSymbol{symbol: "BTC/USD~api.binance.com", granularity: 1000, transform: CurrentMean},
-		after:  &SingleSymbol{symbol: "BTC/USD", granularity: 1000000, transform: CurrentMedian},
-		at:     switchTime,
-	},
+	//2: &TimedSwitch{
+	//	before: &SingleSymbol{symbol: "BTC/USD~api.binance.com", granularity: 1000, transform: MeanAt},
+	//	after:  &SingleSymbol{symbol: "BTC/USD", granularity: 1000000, transform: MedianAt},
+	//	at:     switchTime,
+	//},
 	// 3: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "BNB/USD~dex.binance.org", granularity: 1000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "BNB/USD", granularity: 1000000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "BNB/USD~dex.binance.org", granularity: 1000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "BNB/USD", granularity: 1000000, transform: MedianAt},
 	// 	at:     switchTime,
 	// },
 	// 4: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "BTC/USD", granularity: 100000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "BTC/USD", granularity: 100000, transform: MedianAt},
 	// 	after:  &SingleSymbol{symbol: "BTC/USD", granularity: 1000000, transform: TimeWeightedAvg(24*time.Hour, ExpDecay)},
 	// 	at:     switchTime,
 	// },
 	// 5: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "ETH/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "ETH/BTC", granularity: 1000000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "ETH/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "ETH/BTC", granularity: 1000000, transform: MedianAt},
 	// 	at:     switchTime,
 	// },
-	// 6: &SingleSymbol{symbol: "BNB/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 6: &SingleSymbol{symbol: "BNB/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
 
-	// 7: &SingleSymbol{symbol: "BNB/ETH~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 7: &SingleSymbol{symbol: "BNB/ETH~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 8: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "ETH/USD~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 	before: &SingleSymbol{symbol: "ETH/USD~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 	after:  &SingleSymbol{symbol: "ETH/USD", granularity: 1000000, transform: TimeWeightedAvg(24*time.Hour, ExpDecay)},
 	// 	at:     switchTime,
 	// },
 	// 9: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "LINK/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 	before: &SingleSymbol{symbol: "LINK/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 	after:  &SingleSymbol{symbol: "ETH/USD", granularity: 1000000, transform: EODMedian},
 	// 	at:     switchTime,
 	// },
 	10: &TimedSwitch{
-		before: &SingleSymbol{symbol: "ETC/ETH~api.binance.com", granularity: 1000000, transform: CurrentMean},
-		after:  &ChainedPrice{chain: []string{"AMPL/USD", "AMPL/BTC", "BTC/USD"}, granularity: 1000000, transform: AmpleCustom(NoDecay)},
+		before: &SingleSymbol{symbol: "ETC/ETH~api.binance.com", granularity: 1000000, transform: MeanAt},
+		after:  &Ampl{granularity: 1000000},
 		at:     switchTime,
 	},
-	// 11: &SingleSymbol{symbol: "ZEC/ETH~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 12: &SingleSymbol{symbol: "TRX/ETH~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 11: &SingleSymbol{symbol: "ZEC/ETH~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 12: &SingleSymbol{symbol: "TRX/ETH~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 13: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "XRP/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "XRP/USD", granularity: 1000000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "XRP/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "XRP/USD", granularity: 1000000, transform: MedianAt},
 	// 	at:     switchTime,
 	// },
-	// 14: &SingleSymbol{symbol: "XMR/ETH~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 14: &SingleSymbol{symbol: "XMR/ETH~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 15: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "XLM/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "ATOM/USD", granularity: 1000000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "XLM/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "ATOM/USD", granularity: 1000000, transform: MedianAt},
 	// 	at:     switchTime,
 	// },
-	// 16: &SingleSymbol{symbol: "LTC/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 17: &SingleSymbol{symbol: "WAVES/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 18: &SingleSymbol{symbol: "REP/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 19: &SingleSymbol{symbol: "TUSD/ETH~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 20: &SingleSymbol{symbol: "EOS/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 21: &SingleSymbol{symbol: "IOTA/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 22: &SingleSymbol{symbol: "ETC/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 23: &SingleSymbol{symbol: "ETH/PAX~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 24: &SingleSymbol{symbol: "ETH/USDC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 25: &SingleSymbol{symbol: "USDC/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 16: &SingleSymbol{symbol: "LTC/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 17: &SingleSymbol{symbol: "WAVES/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 18: &SingleSymbol{symbol: "REP/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 19: &SingleSymbol{symbol: "TUSD/ETH~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 20: &SingleSymbol{symbol: "EOS/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 21: &SingleSymbol{symbol: "IOTA/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 22: &SingleSymbol{symbol: "ETC/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 23: &SingleSymbol{symbol: "ETH/PAX~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 24: &SingleSymbol{symbol: "ETH/USDC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 25: &SingleSymbol{symbol: "USDC/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 26: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "RCN/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "DEFISCORE", granularity: 1000000, transform: CurrentMean},
+	// 	before: &SingleSymbol{symbol: "RCN/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "DEFISCORE", granularity: 1000000, transform: MeanAt},
 	// 	at:     switchTime,
 	// },
-	// 27: &SingleSymbol{symbol: "LINK/USDC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 28: &SingleSymbol{symbol: "ZRX/BNB~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 29: &SingleSymbol{symbol: "ZEC/USDC~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 27: &SingleSymbol{symbol: "LINK/USDC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 28: &SingleSymbol{symbol: "ZRX/BNB~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 29: &SingleSymbol{symbol: "ZEC/USDC~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 30: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "DASH/BNB~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "XAU/USD", granularity: 1000000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "DASH/BNB~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "XAU/USD", granularity: 1000000, transform: MedianAt},
 	// 	at:     switchTime,
 	// },
 	// 31: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "MATIC/USD~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "MATIC/USD", granularity: 1000000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "MATIC/USD~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "MATIC/USD", granularity: 1000000, transform: MedianAt},
 	// 	at:     switchTime,
 	// },
-	// 32: &SingleSymbol{symbol: "BAT/USDC~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 33: &SingleSymbol{symbol: "ALGO/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 34: &SingleSymbol{symbol: "ZRX/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 35: &SingleSymbol{symbol: "COS/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 36: &SingleSymbol{symbol: "BCH/USD~api.kraken.com", granularity: 1000000, transform: CurrentMean},
-	// 37: &SingleSymbol{symbol: "REP/USD~api.coingecko.com", granularity: 1000000, transform: CurrentMean},
-	// 38: &SingleSymbol{symbol: "GNO/USD~api.kraken.com", granularity: 1000000, transform: CurrentMean},
-	// 39: &SingleSymbol{symbol: "DAI/USD~api.kraken.com", granularity: 1000000, transform: CurrentMean},
-	// 40: &SingleSymbol{symbol: "STEEM/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 32: &SingleSymbol{symbol: "BAT/USDC~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 33: &SingleSymbol{symbol: "ALGO/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 34: &SingleSymbol{symbol: "ZRX/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 35: &SingleSymbol{symbol: "COS/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 36: &SingleSymbol{symbol: "BCH/USD~api.kraken.com", granularity: 1000000, transform: MeanAt},
+	// 37: &SingleSymbol{symbol: "REP/USD~api.coingecko.com", granularity: 1000000, transform: MeanAt},
+	// 38: &SingleSymbol{symbol: "GNO/USD~api.kraken.com", granularity: 1000000, transform: MeanAt},
+	// 39: &SingleSymbol{symbol: "DAI/USD~api.kraken.com", granularity: 1000000, transform: MeanAt},
+	// 40: &SingleSymbol{symbol: "STEEM/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 41: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "LINK/USDT~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 	after:  &SingleSymbol{symbol: "USPCE", granularity: 1000, transform: CurrentMedian},
+	// 	before: &SingleSymbol{symbol: "LINK/USDT~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 	after:  &SingleSymbol{symbol: "USPCE", granularity: 1000, transform: MedianAt},
 	// 	at:     switchTime,
 	// },
 	// 42: &TimedSwitch{
-	// 	before: &SingleSymbol{symbol: "WAN/BTC~api.binance.com", granularity: 1000000, transform: CurrentMean},
+	// 	before: &SingleSymbol{symbol: "WAN/BTC~api.binance.com", granularity: 1000000, transform: MeanAt},
 	// 	after:  &SingleSymbol{symbol: "BTC/USD", granularity: 1000000, transform: EODMedian},
 	// 	at:     switchTime,
 	// },
-	// 43: &SingleSymbol{symbol: "GNT/ETH~api.binance.com", granularity: 1000000, transform: CurrentMean},
-	// 44: &SingleSymbol{symbol: "BTC/USD~api-pub.bitfinex.com", granularity: 1000000, transform: CurrentMean},
-	// 45: &SingleSymbol{symbol: "BTC/USD~api.coingecko.com", granularity: 1000000, transform: CurrentMean},
-	// 46: &SingleSymbol{symbol: "ETH/USD~api.coingecko.com", granularity: 1000000, transform: CurrentMean},
-	// 47: &SingleSymbol{symbol: "LTC/USD~api.coingecko.com", granularity: 1000000, transform: CurrentMean},
-	// 48: &SingleSymbol{symbol: "MAKER/USD~api.coingecko.com", granularity: 1000000, transform: CurrentMean},
-	// 49: &SingleSymbol{symbol: "EOS/USD~api.coingecko.com", granularity: 1000000, transform: CurrentMean},
-	// 50: &SingleSymbol{symbol: "TRB/USD~api.coingecko.com", granularity: 1000000, transform: CurrentMean},
+	// 43: &SingleSymbol{symbol: "GNT/ETH~api.binance.com", granularity: 1000000, transform: MeanAt},
+	// 44: &SingleSymbol{symbol: "BTC/USD~api-pub.bitfinex.com", granularity: 1000000, transform: MeanAt},
+	// 45: &SingleSymbol{symbol: "BTC/USD~api.coingecko.com", granularity: 1000000, transform: MeanAt},
+	// 46: &SingleSymbol{symbol: "ETH/USD~api.coingecko.com", granularity: 1000000, transform: MeanAt},
+	// 47: &SingleSymbol{symbol: "LTC/USD~api.coingecko.com", granularity: 1000000, transform: MeanAt},
+	// 48: &SingleSymbol{symbol: "MAKER/USD~api.coingecko.com", granularity: 1000000, transform: MeanAt},
+	// 49: &SingleSymbol{symbol: "EOS/USD~api.coingecko.com", granularity: 1000000, transform: MeanAt},
+	// 50: &SingleSymbol{symbol: "TRB/USD~api.coingecko.com", granularity: 1000000, transform: MeanAt},
 }
 
 //these weight functions map values of x between 0 (brand new) and 1 (old) to weights between 0 and 1
@@ -144,12 +144,13 @@ func NoDecay(x float64) (float64, float64) {
 }
 
 func TimeWeightedAvg(interval time.Duration, weightFn func(float64) (float64, float64)) IndexProcessor {
-	return func(apis []*IndexTracker, at time.Time) (float64, float64) {
+	return func(apis []*IndexTracker, at time.Time) (apiOracle.PriceInfo, float64) {
 		cfg := config.GetConfig()
 		sum := 0.0
 		weightSum := 0.0
 		numVals := 0
 		minTime := at
+		maxVolume := 0.0
 		for _, api := range apis {
 			values := apiOracle.GetRequestValuesForTime(api.Identifier, at, interval)
 			for _, v := range values {
@@ -161,6 +162,9 @@ func TimeWeightedAvg(interval time.Duration, weightFn func(float64) (float64, fl
 				if minTime.Sub(v.Created).Seconds() > 0 {
 					minTime = v.Created
 				}
+				if v.Volume > maxVolume {
+					maxVolume = v.Volume
+				}
 			}
 		}
 		// number of APIs * rate * interval
@@ -170,141 +174,127 @@ func TimeWeightedAvg(interval time.Duration, weightFn func(float64) (float64, fl
 		//average weight is the integral of the weight fn over [0,1]
 		_, avgWeight := weightFn(0)
 		targetWeight := maxWeight * avgWeight
-		return sum / weightSum, math.Min(weightSum/targetWeight, 1.0)
+
+		var result apiOracle.PriceInfo
+		result.Price = sum / weightSum
+
+		//use the highest volume seen over all values. works well when the time averaging window is equal to the interval of volume reporting
+		// ie, 24 hour average on an api that returns 24hr volume
+		result.Volume = maxVolume
+		return result, math.Min(weightSum/targetWeight, 1.0)
 	}
 }
 
-//does this properly do what Ampl needs?
-func AmpleCustom(weightFn func(float64) (float64, float64)) IndexProcessor {
-	return func(apis []*IndexTracker, at time.Time) (float64, float64) {
-		//need to handle if it's BTC or AMPL
-
-		//make sure the chained prices is working (everything in USD, not BTC)
-		eod := time.Now().UTC()
-		d := 24 * time.Hour
-		eod = eod.Truncate(d)
-		eod = eod.Add(17 * time.Hour)
-		eod = eod.Add(28 * time.Minute) //make this 2 am for live version
-		//Get the value always at 2am UTC
-		//time weight individual 10 minute buckets
-		//VWAP based on time at 2am
-		i := 0
-		numVals := 0.0
-		uniqueApis := 0.0
-		//volumes := make(map[string]float64)
-		sum := 0.0
-		totalVolume := 0.0
-		for i < 10 {
-			var s []*apiOracle.PriceStamp
-			thistime := eod.Add(time.Duration(i*-10) * time.Minute)
-			btcusdPrice := PSRs[2].ValueAt(thistime)
-			fmt.Println("BTC price", btcusdPrice)
-			// for _, api := range apis {
-			// 	values := apiOracle.GetRequestValuesForTime(api.Identifier, thistime, 2*time.Minute)
-			// 	for _, v := range values {
-			// 		s = append(s, v)
-			// 	}
-			// 	if api.Symbols[0] == "AMPL/BTC" {
-			// 		for _, stuff := range s {
-			// 			stuff.Volume = stuff.Volume * btcusdPrice.Price
-			// 			stuff.Price = stuff.Price * btcusdPrice.Price
-			// 		}
-			// 	}
-			// 	if api.Symbols[0] == "AMPL/BTC" || api.Symbols[0] == "AMPL/USD" {
-			// 		if i == 0 && len(s) > 0 {
-			// 			sort.Slice(s, func(i, j int) bool {
-			// 				return s[i].Volume < s[j].Volume
-			// 			})
-			// 			if s[len(s)-1].Volume > 0 {
-			// 				volumes[api.Identifier] = s[len(s)-1].Volume //get max volume this interval
-			// 			} else {
-			// 				volumes[api.Identifier] = 1 //set to 1 if no volume number (handles if apis w/volume go down)
-			// 			}
-
-			// 			totalVolume += s[len(s)-1].Volume
-			// 		}
-			// 		if len(s) > 0 {
-			// 			//fmt.Println("API.Identifier", api.Identifier, "    Price:  ", s[len(s)/2].Price)
-			// 			sort.Slice(s, func(i, j int) bool {
-			// 				return s[i].Price < s[j].Price
-			// 			})
-			// 			sum += volumes[api.Identifier] * (s[len(s)/2].Price)
-			// 			numVals += 1
-			// 		}
-			// 	}
-
-			// }
-			if len(s) > 0 {
-				uniqueApis += 1
+func VolumeWeightedAPIs(processor IndexProcessor) IndexProcessor {
+	return func(apis []*IndexTracker, at time.Time) (apiOracle.PriceInfo, float64) {
+		var results []apiOracle.PriceInfo
+		totalConfidence := 0.0
+		for _,api := range apis {
+			value, confidence := processor([]*IndexTracker{api}, at)
+			fmt.Printf("AMPL api %s: %f (%f)\n", api.Name, value, confidence)
+			if confidence > 0.3 {
+				results = append(results, value)
+				totalConfidence += confidence
 			}
-			i++
 		}
-		fmt.Println(numVals, "taken as part of the AMPL piece")
-		fmt.Println("uniqueAPIs : ", uniqueApis)
-		fmt.Println("Ample Price", sum/totalVolume/numVals, "   : Ample Confidence:  ", numVals/(144.0*uniqueApis))
-		if sum > 0 && totalVolume > 0 {
-			return sum / totalVolume / numVals, numVals / (144.0 * uniqueApis)
-		} else {
-			return 0, 0
-		}
+		return VolumeWeightedAvg(results), totalConfidence/float64(len(results))
 	}
 }
 
-func getLatest(apis []*IndexTracker, at time.Time) ([]*apiOracle.PriceStamp, float64) {
-	var values []*apiOracle.PriceStamp
+func getLatest(apis []*IndexTracker, at time.Time) ([]apiOracle.PriceInfo, float64) {
+	var values []apiOracle.PriceInfo
 	totalConf := 0.0
 	for _, api := range apis {
 		b, _ := apiOracle.GetNearestTwoRequestValue(api.Identifier, at)
 		if b != nil {
 			//penalize values more than 5 minutes old
 			totalConf += math.Min(5/at.Sub(b.Created).Minutes(), 1.0)
-			values = append(values, b)
+			values = append(values, b.PriceInfo)
 		}
 	}
 	return values, totalConf / float64(len(apis))
 }
 
-func CurrentMedian(apis []*IndexTracker, at time.Time) (float64, float64) {
+func MedianAt(apis []*IndexTracker, at time.Time) (apiOracle.PriceInfo, float64) {
 	values, confidence := getLatest(apis, at)
 	if confidence == 0 {
-		return 0, 0
+		return apiOracle.PriceInfo{}, 0
 	}
+	return Median(values), confidence
+}
+
+func MedianAtEOD(apis []*IndexTracker, at time.Time) (apiOracle.PriceInfo, float64) {
+	now := time.Now().UTC()
+	d := 24 * time.Hour
+	eod := now.Truncate(d)
+	return MedianAt(apis, eod)
+	//interval := 2 * time.Minute
+	//var s []*apiOracle.PriceStamp
+	//for _, api := range apis {
+	//	values := apiOracle.GetRequestValuesForTime(api.Identifier, eod, interval)
+	//	for _, v := range values {
+	//		s = append(s, v)
+	//	}
+	//}
+	//if len(s) > 0 {
+	//	sort.Slice(s, func(i, j int) bool {
+	//		return s[i].Price < s[j].Price
+	//	})
+	//	return s[len(s)/2].Price, float64(len(s) / len(apis))
+	//}
+	//return 0, 0
+}
+
+func Median(values []apiOracle.PriceInfo) apiOracle.PriceInfo {
+	var result apiOracle.PriceInfo
 	sort.Slice(values, func(i, j int) bool {
 		return values[i].Price < values[j].Price
 	})
 	fmt.Println("median of ", len(values))
-	return values[len(values)/2].Price, confidence
+	result.Price = values[len(values)/2].Price
+	for _, val := range values {
+		result.Volume += val.Volume
+	}
+	return result
 }
 
-func CurrentMean(apis []*IndexTracker, at time.Time) (float64, float64) {
+func MeanAt(apis []*IndexTracker, at time.Time) (apiOracle.PriceInfo, float64) {
 	values, confidence := getLatest(apis, at)
 	if confidence == 0 {
-		return 0, 0
+		return apiOracle.PriceInfo{}, 0
 	}
-	sum := 0.0
-	for _, val := range values {
-		sum += val.Price
-	}
-	return sum / float64(len(values)), confidence
+	return Mean(values), confidence
 }
 
-func EODMedian(apis []*IndexTracker, at time.Time) (float64, float64) {
-	eod := time.Now().UTC()
-	d := 24 * time.Hour
-	eod = eod.Truncate(d)
-	interval := 2 * time.Minute
-	var s []*apiOracle.PriceStamp
-	for _, api := range apis {
-		values := apiOracle.GetRequestValuesForTime(api.Identifier, eod, interval)
-		for _, v := range values {
-			s = append(s, v)
-		}
+func Mean(vals []apiOracle.PriceInfo) apiOracle.PriceInfo {
+	var result apiOracle.PriceInfo
+	priceSum := 0.0
+	volSum := 0.0
+	for _, val := range vals {
+		priceSum += val.Price
+		volSum += val.Volume
 	}
-	if len(s) > 0 {
-		sort.Slice(s, func(i, j int) bool {
-			return s[i].Price < s[j].Price
-		})
-		return s[len(s)/2].Price, float64(len(s) / len(apis))
-	}
-	return 0, 0
+	result.Price = priceSum / float64(len(vals))
+	result.Volume = volSum
+	return result
 }
+
+
+func VolumeWeightedAvg(vals []apiOracle.PriceInfo) apiOracle.PriceInfo {
+	priceSum := 0.0
+	volSum := 0.0
+	for _, val := range vals {
+		priceSum += val.Price * val.Volume
+		volSum += val.Volume
+	}
+	if volSum > 0 {
+		return apiOracle.PriceInfo{Price: priceSum / volSum, Volume: volSum}
+	}
+	//if there was no volume data, just do a normal average instead
+	priceSum = 0
+	for _, val := range vals {
+		priceSum += val.Price
+	}
+	return apiOracle.PriceInfo{Price: priceSum / float64(len(vals)), Volume: 0}
+}
+

--- a/tracker/singleSymbol.go
+++ b/tracker/singleSymbol.go
@@ -1,6 +1,9 @@
 package tracker
 
-import "time"
+import (
+	"github.com/tellor-io/TellorMiner/apiOracle"
+	"time"
+)
 
 type SingleSymbol struct {
 	symbol      string
@@ -14,8 +17,8 @@ func (s SingleSymbol)Require(at time.Time) map[string]IndexProcessor {
 	return r
 }
 
-func (s SingleSymbol) ValueAt(vals map[string]float64, at time.Time) float64 {
-	return vals[s.symbol] * s.granularity
+func (s SingleSymbol) ValueAt(vals map[string]apiOracle.PriceInfo, at time.Time) float64 {
+	return vals[s.symbol].Price * s.granularity
 }
 
 

--- a/tracker/timedSwitch.go
+++ b/tracker/timedSwitch.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"github.com/tellor-io/TellorMiner/apiOracle"
 	"time"
 )
 
@@ -18,7 +19,7 @@ func (t *TimedSwitch) Require(at time.Time) map[string]IndexProcessor {
 	}
 }
 
-func (t *TimedSwitch) ValueAt(vals map[string]float64, at time.Time) float64 {
+func (t *TimedSwitch) ValueAt(vals map[string]apiOracle.PriceInfo, at time.Time) float64 {
 	//dont check time here, only in require. we don't want this to change mid-cycle
 	//and pass the old requirements to the new processor
 	if at.After(t.at) {

--- a/tracker/valueGenerators.go
+++ b/tracker/valueGenerators.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"context"
 	"fmt"
+	"github.com/tellor-io/TellorMiner/apiOracle"
 	"math"
 	"math/big"
 	"time"
@@ -13,7 +14,7 @@ import (
 )
 
 //a function to consolidate the recorded API values to a single value
-type IndexProcessor func([]*IndexTracker, time.Time) (float64, float64)
+type IndexProcessor func([]*IndexTracker, time.Time) (apiOracle.PriceInfo, float64)
 
 type ValueGenerator interface {
 	//PSRs report what they require to produce a value with this
@@ -21,7 +22,7 @@ type ValueGenerator interface {
 
 	//return the best estimate of a value at a given time, and the confidence
 	// if confidence == 0, the value has no meaning
-	ValueAt(map[string]float64, time.Time) float64
+	ValueAt(map[string]apiOracle.PriceInfo, time.Time) float64
 }
 
 func InitPSRs() error {
@@ -42,7 +43,7 @@ func InitPSRs() error {
 func PSRValueForTime(requestID int, at time.Time) (float64, float64) {
 	//get the requirements
 	reqs := PSRs[requestID].Require(at)
-	values := make(map[string]float64)
+	values := make(map[string]apiOracle.PriceInfo)
 	minConfidence := math.MaxFloat64
 	for symbol, fn := range reqs {
 		val, confidence := fn(indexes[symbol], at)


### PR DESCRIPTION
still needs some work, but I think you can handle it from here. The `AmpleChained` function maps a single pair at a time (like AMPL/BTC) to AMPL/USD by using the BTC/USD price. The Ampl custom `ValueAt` function takes all the separate sources for AMPL/USD and does a final volume weighting to combine them into a single value. 