### PR TITLE
Add coverage CI for tracker package

### DIFF
--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -1,0 +1,14 @@
+name: Coverage
+on: push
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.13.3" # The Go version to download (if necessary) and use.
+      - run: go version
+      - run: go get -d .
+      - run: ./runPkgTest.sh tracker

--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -12,3 +12,12 @@ jobs:
       - run: go version
       - run: go get -d .
       - run: ./runPkgTest.sh tracker
+      - uses: jandelgado/gcov2lcov-action@v1.0.2
+        with:
+          infile: trackercoverage.out
+          outfile: coverage.lcov
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage.lcov


### PR DESCRIPTION
This Github action will run Tracker tests and publish coverage results to [Coveralls.io](https://coveralls.io/github/topocount/TellorMiner)