### PR TITLE
fix the log level param parsing

### DIFF
--- a/pkg/dataServer/dataServer_test.go
+++ b/pkg/dataServer/dataServer_test.go
@@ -17,7 +17,8 @@ import (
 
 func TestDataServer(t *testing.T) {
 	exitCh := make(chan int)
-	logger := util.SetupLogger("debug")
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
 	ctx, cfg, cleanup := testutil.CreateContext(t)
 	defer t.Cleanup(cleanup)
 

--- a/pkg/ops/dataServerOps_test.go
+++ b/pkg/ops/dataServerOps_test.go
@@ -15,7 +15,8 @@ import (
 func TestDataServerOps(t *testing.T) {
 
 	exitCh := make(chan os.Signal)
-	logger := util.SetupLogger("debug")
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
 	ctx, _, cleanup := testutil.CreateContext(t)
 	defer t.Cleanup(cleanup)
 

--- a/pkg/tracker/balance_test.go
+++ b/pkg/tracker/balance_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestStringId(t *testing.T) {
-	tracker := NewBalanceTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewBalanceTracker(logger)
 	res := tracker.String()
 	if res != BalanceTrackerName {
 		t.Fatal("didn't return expected string", BalanceTrackerName)
@@ -44,7 +46,9 @@ func TestNegativeBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tracker := NewBalanceTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewBalanceTracker(logger)
 	ctx := context.WithValue(context.Background(), common.ClientContextKey, client)
 	ctx = context.WithValue(ctx, common.DBContextKey, DB)
 	err = tracker.Exec(ctx)
@@ -62,7 +66,9 @@ func dbBalanceTest(startBal *big.Int, t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tracker := NewBalanceTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewBalanceTracker(logger)
 	ctx := context.WithValue(context.Background(), common.ClientContextKey, client)
 	ctx = context.WithValue(ctx, common.DBContextKey, DB)
 	err = tracker.Exec(ctx)

--- a/pkg/tracker/disputeChecker_test.go
+++ b/pkg/tracker/disputeChecker_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestDisputeCheckerInRange(t *testing.T) {
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
 	ctx, _, cleanup := testutil.CreateContext(t)
 	t.Cleanup(cleanup)
 
@@ -25,7 +27,7 @@ func TestDisputeCheckerInRange(t *testing.T) {
 	execEthUsdPsrs(ctx, t, ethUSDPairs)
 	time.Sleep(2 * time.Second)
 	execEthUsdPsrs(ctx, t, ethUSDPairs)
-	disputeChecker := &disputeChecker{lastCheckedBlock: 500, logger: util.SetupLogger("debug")}
+	disputeChecker := &disputeChecker{lastCheckedBlock: 500, logger: logger}
 	err := disputeChecker.Exec(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +38,9 @@ func TestDisputeCheckerOutOfRange(t *testing.T) {
 	ctx, cfg, cleanup := testutil.CreateContext(t)
 	t.Cleanup(cleanup)
 	cfg.DisputeThreshold = 0.000000001
-	disputeChecker := NewDisputeChecker(util.SetupLogger("debug"), 500)
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	disputeChecker := NewDisputeChecker(logger, 500)
 	if _, err := BuildIndexTrackers(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/tracker/disputeStatus_test.go
+++ b/pkg/tracker/disputeStatus_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestDisputeString(t *testing.T) {
-	tracker := NewDisputeTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewDisputeTracker(logger)
 	res := tracker.String()
 	if res != DisputeTrackerName {
 		t.Fatal("didn't return expected string", DisputeTrackerName)
@@ -35,7 +37,9 @@ func TestDisputeStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tracker := NewDisputeTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewDisputeTracker(logger)
 	ctx := context.WithValue(context.Background(), common.ClientContextKey, client)
 	ctx = context.WithValue(ctx, common.DBContextKey, DB)
 	err = tracker.Exec(ctx)

--- a/pkg/tracker/factory_test.go
+++ b/pkg/tracker/factory_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestCreateTracker(t *testing.T) {
 
-	logger := util.SetupLogger("debug")
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
 	balanceTracker, _ := createTracker("balance", logger)
 	if balanceTracker[0].String() != BalanceTrackerName {
 		t.Fatalf("Expected BalanceTracker but got %s", balanceTracker[0].String())

--- a/pkg/tracker/gas_test.go
+++ b/pkg/tracker/gas_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestETHGasStation(t *testing.T) {
-	tracker := NewGasTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewGasTracker(logger)
 	opts := &rpc.MockOptions{ETHBalance: big.NewInt(300000), Nonce: 1, GasPrice: big.NewInt(7000000000),
 		TokenBalance: big.NewInt(0), Top50Requests: []*big.Int{}}
 	client := rpc.NewMockClientWithValues(opts)

--- a/pkg/tracker/runner_test.go
+++ b/pkg/tracker/runner_test.go
@@ -20,7 +20,8 @@ import (
 
 func TestRunner(t *testing.T) {
 	ctx, _, cleanup := testutil.CreateContext(t)
-	logger := util.SetupLogger("debug")
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
 	defer t.Cleanup(cleanup)
 
 	exitCh := make(chan int)

--- a/pkg/tracker/timeOut_test.go
+++ b/pkg/tracker/timeOut_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestTimeOutString(t *testing.T) {
-	tracker := NewTimeOutTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewTimeOutTracker(logger)
 	res := tracker.String()
 	if res != "TimeOutTracker" {
 		t.Fatalf("should return 'TimeOutTracker' string")
@@ -41,7 +43,9 @@ func TestTimeOutTracker(t *testing.T) {
 	ctx = context.WithValue(ctx, common.ClientContextKey, client)
 	ctx = context.WithValue(ctx, common.DBContextKey, db)
 
-	tracker := NewTimeOutTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewTimeOutTracker(logger)
 	if err := tracker.Exec(ctx); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/tracker/tributeBalance_test.go
+++ b/pkg/tracker/tributeBalance_test.go
@@ -27,7 +27,9 @@ func TestTributeBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tracker := NewTributeTracker(util.SetupLogger("debug"))
+	logSetup := util.SetupLogger()
+	logger := logSetup("debug")
+	tracker := NewTributeTracker(logger)
 	ctx := context.WithValue(context.Background(), common.ClientContextKey, client)
 	ctx = context.WithValue(ctx, common.DBContextKey, DB)
 	err = tracker.Exec(ctx)

--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -151,23 +151,24 @@ func xlateLevel(level LogLevel) logrus.Level {
 
 }
 
-func SetupLogger(logLevel string) log.Logger {
-	var lvl level.Option
-	switch logLevel {
-	case "error":
-		lvl = level.AllowError()
-	case "warn":
-		lvl = level.AllowWarn()
-	case "info":
-		lvl = level.AllowInfo()
-	case "debug":
-		lvl = level.AllowDebug()
-	default:
-		panic("unexpected log level")
+func SetupLogger() func(string) log.Logger {
+	return func(logLevel string) log.Logger {
+		var lvl level.Option
+		switch logLevel {
+		case "error":
+			lvl = level.AllowError()
+		case "warn":
+			lvl = level.AllowWarn()
+		case "info":
+			lvl = level.AllowInfo()
+		case "debug":
+			lvl = level.AllowDebug()
+		default:
+			panic("unexpected log level")
+		}
+
+		logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+		logger = level.NewFilter(logger, lvl)
+		return log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 	}
-
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = level.NewFilter(logger, lvl)
-
-	return log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 }


### PR DESCRIPTION
`*logLevel` is populated with the actual cli value only after running `app.Run` that is why need to pass the logLevel flag all the way to `cmd.Action` 

Without this `logLevel` always used the default value.

If we use kingip they API there is better so can remove this workaround
I have opened an issue for that https://github.com/tellor-io/TellorMiner/issues/240
