### PR TITLE
Make the docker repo name dinamicaly linked to the gh repo name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,7 @@ jobs:
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: tellor/tellor # list of Docker images to use as base name for tags
-          tag-sha: true # add git short SHA as Docker tag
+          images: ${{ github.repository }} # list of Docker images to use as base name for tags
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: tellor/miner # list of Docker images to use as base name for tags
+          images: tellor/tellor # list of Docker images to use as base name for tags
           tag-sha: true # add git short SHA as Docker tag
       -
         name: Set up QEMU

--- a/scripts/copyright/copyright.go
+++ b/scripts/copyright/copyright.go
@@ -1,9 +1,6 @@
 // Copyright (c) The Tellor Authors.
 // Licensed under the MIT License.
 
-// Copyright (c) The Thanos Authors.
-// Licensed under the Apache License 2.0.
-
 package main
 
 import (


### PR DESCRIPTION
As mentioned in the chat lets move towards renaming it to just tellor as this cli does more then just mining - this is the tellor cli tool - 

you can run it as a miner
only as a values submitter
for voting
for opening disputes
....